### PR TITLE
Support multi-repo workspaces

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { EXTENSION_NAME } from "./constants";
-import { getGitApi } from "./git";
+import { getGitApi, GitAPI, Repository } from "./git";
 import { updateContext } from "./utils";
 import { commit } from "./watcher";
 
@@ -11,10 +11,13 @@ interface GitTimelineItem {
 }
 
 export function registerCommands(context: vscode.ExtensionContext) {
+  function getRepo(git: GitAPI): Repository | null {
+    const uri = vscode.window.activeTextEditor?.document.uri;
+    if (uri) return git.getRepository(uri);
+    return git.repositories[0] ?? null;
+  }
   function registerCommand(name: string, callback: (...args: any[]) => any) {
-    context.subscriptions.push(
-      vscode.commands.registerCommand(`${EXTENSION_NAME}.${name}`, callback)
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(`${EXTENSION_NAME}.${name}`, callback));
   }
 
   registerCommand("enable", updateContext.bind(null, true));
@@ -25,20 +28,19 @@ export function registerCommands(context: vscode.ExtensionContext) {
       return;
     }
 
-    const path = vscode.workspace.asRelativePath(
-      vscode.window.activeTextEditor.document.uri.path
-    );
+    const path = vscode.workspace.asRelativePath(vscode.window.activeTextEditor.document.uri.path);
 
     const git = await getGitApi();
+    if (!git) return;
+    const repo = git.getRepository(vscode.window.activeTextEditor.document.uri);
+    if (!repo) return;
 
     // @ts-ignore
-    await git?.repositories[0].repository.repository.checkout(item.ref, [
-      path,
-    ]);
+    await repo.repository.repository.checkout(item.ref, [path]);
 
     // TODO: Look into why the checkout
     // doesn't trigger the watcher.
-    commit(git?.repositories[0]!);
+    commit(repo);
   });
 
   registerCommand("squashVersions", async (item: GitTimelineItem) => {
@@ -47,31 +49,35 @@ export function registerCommands(context: vscode.ExtensionContext) {
       value: item.message,
     });
 
-    if (message) {
-      const git = await getGitApi();
-      // @ts-ignore
-      await git?.repositories[0].repository.reset(`${item.ref}~1`);
-      await commit(git?.repositories[0]!, message);
-    }
+    if (!message) return;
+    const git = await getGitApi();
+    if (!git) return;
+    const repo = getRepo(git);
+    if (!repo) return;
+    // @ts-ignore
+    await repo.repository.reset(`${item.ref}~1`);
+    await commit(repo, message);
   });
 
   registerCommand("undoVersion", async (item: GitTimelineItem) => {
     const git = await getGitApi();
-
+    if (!git) return;
+    const repo = getRepo(git);
+    if (!repo) return;
     // @ts-ignore
-    await git?.repositories[0].repository.repository.run([
+    await repo.repository.repository.run([
       "revert",
       "-n", // Tell Git not to create a commit, so that we can make one with the right message format
       item.ref,
     ]);
 
-    await commit(git?.repositories[0]!);
+    await commit(repo);
   });
 
   registerCommand("commit", async () => {
     const git = await getGitApi();
-    if (git && git.repositories.length > 0) {
-      await commit(git.repositories[0]);
-    }
+    if (!git) return;
+    const repo = getRepo(git);
+    if (repo) await commit(repo);
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import { reaction } from "mobx";
 import * as vscode from "vscode";
 import { registerCommands } from "./commands";
 import config from "./config";
-import { getGitApi, GitAPI, RefType } from "./git";
+import { getGitApi, GitAPI, RefType, Repository } from "./git";
 import { store } from "./store";
 import { commit, watchForChanges } from "./watcher";
 import { updateContext } from "./utils";
@@ -27,18 +27,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
   reaction(
     () => [store.enabled],
-    () => checkEnabled(git)
+    () => checkEnabled(git),
   );
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("gitdoc.enabled") ||
+      if (
+        e.affectsConfiguration("gitdoc.enabled") ||
         e.affectsConfiguration("gitdoc.excludeBranches") ||
         e.affectsConfiguration("gitdoc.autoCommitDelay") ||
-        e.affectsConfiguration("gitdoc.filePattern")) {
+        e.affectsConfiguration("gitdoc.filePattern")
+      ) {
         checkEnabled(git);
       }
-    })
+    }),
   );
 }
 
@@ -49,29 +51,25 @@ async function checkEnabled(git: GitAPI) {
     watcher = null;
   }
 
-  let branchName = git.repositories[0]?.state?.HEAD?.name;
-
-  if (!branchName) {
-    const refs = await git.repositories[0]?.getRefs();
-    branchName = refs?.find((ref) => ref.type === RefType.Head)?.name;
+  const repos: Repository[] = [];
+  for (const repo of git.repositories) {
+    let branch = repo.state.HEAD?.name;
+    if (!branch) {
+      const refs = await repo.getRefs();
+      branch = refs.find((r) => r.type === RefType.Head)?.name;
+    }
+    if (branch && !config.excludeBranches.includes(branch)) repos.push(repo);
   }
 
-  const enabled =
-    git.repositories.length > 0 &&
-    store.enabled && !!branchName && !config.excludeBranches.includes(branchName);
-
+  const enabled = repos.length > 0 && store.enabled;
   updateContext(enabled, false);
 
-  if (enabled) {
-    watcher = watchForChanges(git);
-  }
+  if (enabled) watcher = watchForChanges(repos);
 }
 
 export async function deactivate() {
-  if (store.enabled && config.commitOnClose) {
-    const git = await getGitApi();
-    if (git && git.repositories.length > 0) {
-      return commit(git.repositories[0]);
-    }
-  }
+  if (!store.enabled || !config.commitOnClose) return;
+  const git = await getGitApi();
+  if (!git) return;
+  for (const repo of git.repositories) await commit(repo);
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import config from "./config";
-import { ForcePushMode, GitAPI, Repository, RefType } from "./git";
+import { ForcePushMode, Repository, RefType } from "./git";
 import { DateTime } from "luxon";
 import { store } from "./store";
 import { reaction } from "mobx";
@@ -8,10 +8,7 @@ import * as minimatch from "minimatch";
 
 const REMOTE_NAME = "origin";
 
-async function pushRepository(
-  repository: Repository,
-  forcePush: boolean = false
-) {
+async function pushRepository(repository: Repository, forcePush: boolean = false) {
   if (!(await hasRemotes(repository))) return;
 
   store.isPushing = true;
@@ -26,10 +23,7 @@ async function pushRepository(
     if (forcePush) {
       pushArgs.push(ForcePushMode.Force);
     } else if (config.pushMode !== "push") {
-      const pushMode =
-        config.pushMode === "forcePush"
-          ? ForcePushMode.Force
-          : ForcePushMode.ForceWithLease;
+      const pushMode = config.pushMode === "forcePush" ? ForcePushMode.Force : ForcePushMode.ForceWithLease;
 
       pushArgs.push(pushMode);
     }
@@ -40,12 +34,7 @@ async function pushRepository(
   } catch {
     store.isPushing = false;
 
-    if (
-      await vscode.window.showWarningMessage(
-        "Remote repository contains conflicting changes.",
-        "Force Push"
-      )
-    ) {
+    if (await vscode.window.showWarningMessage("Remote repository contains conflicting changes.", "Force Push")) {
       await pushRepository(repository, true);
     }
   }
@@ -79,7 +68,8 @@ async function generateCommitMessage(repository: Repository, changedUris: vscode
       return `## ${filePath}
 ---
 ${fileDiff}`;
-    }));
+    }),
+  );
 
   const model = await vscode.lm.selectChatModels({ family: config.aiModel });
   if (!model || model.length === 0) return null;
@@ -98,19 +88,25 @@ ${config.aiUseEmojis ? "* Prepend an emoji to the message that expresses the nat
 
 ${diffs.join("\n\n")}
 
-${config.aiCustomInstructions ? `# Additional Instructions (Important!)
+${
+  config.aiCustomInstructions
+    ? `# Additional Instructions (Important!)
   
 ${config.aiCustomInstructions}
-` : ""}
+`
+    : ""
+}
 # Commit message
 
 `;
 
-  const response = await model[0].sendRequest([{
-    role: vscode.LanguageModelChatMessageRole.User,
-    name: "User",
-    content: prompt
-  }]);
+  const response = await model[0].sendRequest([
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      name: "User",
+      content: prompt,
+    },
+  ]);
 
   let summary = "";
   for await (const part of response.text) {
@@ -121,9 +117,14 @@ ${config.aiCustomInstructions}
 }
 
 export async function commit(repository: Repository, message?: string) {
-  // This function shouldn't ever be called when GitDoc
-  // is disabled, but we're checking it just in case.
   if (store.enabled === false) return;
+
+  let branch = repository.state.HEAD?.name;
+  if (!branch) {
+    const refs = await repository.getRefs();
+    branch = refs.find((r) => r.type === RefType.Head)?.name;
+  }
+  if (!branch || config.excludeBranches.includes(branch)) return;
 
   const changes = [
     ...repository.state.workingTreeChanges,
@@ -133,30 +134,22 @@ export async function commit(repository: Repository, message?: string) {
 
   if (changes.length === 0) return;
 
-  const changedUris = changes
-    .filter((change) => matches(change.uri))
-    .map((change) => change.uri);
+  const changedUris = changes.filter((change) => matches(change.uri)).map((change) => change.uri);
 
   if (changedUris.length === 0) return;
 
   if (config.commitValidationLevel !== "none") {
-    const diagnostics = vscode.languages
-      .getDiagnostics()
-      .filter(([uri, diagnostics]) => {
-        const isChanged = changedUris.find(
-          (changedUri) =>
-            changedUri.toString().localeCompare(uri.toString()) === 0
-        );
+    const diagnostics = vscode.languages.getDiagnostics().filter(([uri, diagnostics]) => {
+      const isChanged = changedUris.find((changedUri) => changedUri.toString().localeCompare(uri.toString()) === 0);
 
-        return isChanged
-          ? diagnostics.some(
+      return isChanged
+        ? diagnostics.some(
             (diagnostic) =>
               diagnostic.severity === vscode.DiagnosticSeverity.Error ||
-              (config.commitValidationLevel === "warning" &&
-                diagnostic.severity === vscode.DiagnosticSeverity.Warning)
+              (config.commitValidationLevel === "warning" && diagnostic.severity === vscode.DiagnosticSeverity.Warning),
           )
-          : false;
-      });
+        : false;
+    });
 
     if (diagnostics.length > 0) {
       return;
@@ -219,7 +212,7 @@ function debouncedCommit(repository: Repository) {
   if (!commitMap.has(repository)) {
     commitMap.set(
       repository,
-      debounce(() => commit(repository), config.autoCommitDelay)
+      debounce(() => commit(repository), config.autoCommitDelay),
     );
   }
 
@@ -229,9 +222,7 @@ function debouncedCommit(repository: Repository) {
 let statusBarItem: vscode.StatusBarItem | null = null;
 export function ensureStatusBarItem() {
   if (!statusBarItem) {
-    statusBarItem = vscode.window.createStatusBarItem(
-      vscode.StatusBarAlignment.Left
-    );
+    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 
     statusBarItem.text = "$(mirror)";
     statusBarItem.tooltip = "GitDoc: Auto-commiting files on save";
@@ -243,9 +234,23 @@ export function ensureStatusBarItem() {
 }
 
 let disposables: vscode.Disposable[] = [];
-export function watchForChanges(git: GitAPI): vscode.Disposable {
-  const commitAfterDelay = debouncedCommit(git.repositories[0]);
-  disposables.push(git.repositories[0].state.onDidChange(commitAfterDelay));
+export function watchForChanges(repositories: Repository[]): vscode.Disposable {
+  repositories.forEach((repo) => {
+    const commitAfterDelay = debouncedCommit(repo);
+    disposables.push(repo.state.onDidChange(commitAfterDelay));
+
+    if (config.autoPush === "afterDelay") {
+      const interval = setInterval(() => pushRepository(repo), config.autoPushDelay);
+      disposables.push({ dispose: () => clearInterval(interval) });
+    }
+
+    if (config.autoPull === "afterDelay") {
+      const interval = setInterval(() => pullRepository(repo), config.autoPullDelay);
+      disposables.push({ dispose: () => clearInterval(interval) });
+    }
+
+    if (config.pullOnOpen) pullRepository(repo);
+  });
 
   ensureStatusBarItem();
 
@@ -253,16 +258,13 @@ export function watchForChanges(git: GitAPI): vscode.Disposable {
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor && matches(editor.document.uri)) {
         statusBarItem?.show();
-      } else {
-        statusBarItem?.hide();
+        return;
       }
-    })
+      statusBarItem?.hide();
+    }),
   );
 
-  if (
-    vscode.window.activeTextEditor &&
-    matches(vscode.window.activeTextEditor.document.uri)
-  ) {
+  if (vscode.window.activeTextEditor && matches(vscode.window.activeTextEditor.document.uri)) {
     statusBarItem?.show();
   } else {
     statusBarItem?.hide();
@@ -275,52 +277,19 @@ export function watchForChanges(git: GitAPI): vscode.Disposable {
     },
   });
 
-  if (config.autoPush === "afterDelay") {
-    const interval = setInterval(async () => {
-      pushRepository(git.repositories[0]);
-    }, config.autoPushDelay);
-
-    disposables.push({
-      dispose: () => {
-        clearInterval(interval);
-      },
-    });
-  }
-
-  if (config.autoPull === "afterDelay") {
-    const interval = setInterval(
-      async () => pullRepository(git.repositories[0]),
-      config.autoPullDelay
-    );
-
-    disposables.push({
-      dispose: () => clearInterval(interval),
-    });
-  }
-
   const reactionDisposable = reaction(
     () => [store.isPushing, store.isPulling],
     () => {
-      const suffix = store.isPushing
-        ? " (Pushing...)"
-        : store.isPulling
-          ? " (Pulling...)"
-          : "";
+      const suffix = store.isPushing ? " (Pushing...)" : store.isPulling ? " (Pulling...)" : "";
       statusBarItem!.text = `$(mirror)${suffix}`;
-    }
+    },
   );
 
-  disposables.push({
-    dispose: reactionDisposable,
-  });
-
-  if (config.pullOnOpen) {
-    pullRepository(git.repositories[0]);
-  }
+  disposables.push({ dispose: reactionDisposable });
 
   return {
     dispose: () => {
-      disposables.forEach((disposable) => disposable.dispose());
+      disposables.forEach((d) => d.dispose());
       disposables = [];
     },
   };


### PR DESCRIPTION
## Problem
GitDoc only monitored the first git repository, leaving other repositories in a multi-root workspace uncommitted.

## Changes
- handle active file repository in all commands (`src/commands.ts`)
- track valid repositories and commit them on deactivate (`src/extension.ts`)
- watch, commit, push, and pull per repository (`src/watcher.ts`)

## Review
- **Safe**: helper selection of active repository, commit-on-close loop.
- **Needs scrutiny**: watcher loops over repositories and branch filtering.

## Verification
1. Open a workspace containing multiple git repositories.
2. Enable GitDoc.
3. Edit and save a file in a non-primary repository.
4. Observe commits/pushes occur in the correct repository.

## Deployment
- **Risk**: multiple repositories may trigger concurrent push/pull.
- **Mitigation**: operations are debounced per repository and branch-filtered.

## Learning
- VS Code's Git API supports repository lookup per file; leveraging it enables multi-repo automation.

------
https://chatgpt.com/codex/tasks/task_e_68919248e498832c9c4b3f6630fb0c80